### PR TITLE
better parsing of proxmox backup file names, small bugfixing

### DIFF
--- a/check_proxmox_backup.sh
+++ b/check_proxmox_backup.sh
@@ -39,12 +39,12 @@ MAX_OLD_DAYS=$3
 
 # Check if KVM or LXC
 #KVM
-if qm list |grep $ID > /dev/null 2>&1 ; then
+if sudo /usr/sbin/qm list |grep $ID > /dev/null 2>&1 ; then
  TYPE="qemu"
 fi
 #OPENVZ
 if [[ -f $PVECTL ]] ; then
- if $PVECTL list |grep $ID > /dev/null 2>&1 ; then
+ if sudo $PVECTL list |grep $ID > /dev/null 2>&1 ; then
    TYPE="openvz"
  fi
 fi
@@ -66,19 +66,31 @@ fi
 line=$(cat $LIST | tail -1)
 
 # Really, really ugly, but gets the job done. If you have a better way, please don't hesitate to contact me.
-size=$(echo $line | tr -d "[A-Z][a-z][.][:][/][\-]" | cut -c 4- | sed 's/[^ ]* //' | tr -d "[ ]")
-size="$(( $size / 1024 ))"
-size="$(( $size / 1024 ))"
-year=$(echo $line | tr -d "[A-Z][a-z][.][:][/]" | cut -c 7- | cut -d' ' -f1 | grep -oP "[0-9]{4}")
-month=$(echo $line | tr -d "[A-Z][a-z][.][:][/]" | cut -d' ' -f1 | cut -c 12-)
-month=$(echo ${month::2})
-day=$(echo $line | tr -d "[A-Z][a-z][.][:][/]" |  cut -d' ' -f1 | cut -c 15-)
-day=$(echo ${day::2})
-hour=$(echo $line | tr -d "[A-Z][a-z][.][:][/]" |  cut -d' ' -f1 | cut -c 18-)
-hour=$(echo ${hour::2})
-minute=$(echo $line | tr -d "[A-Z][a-z][.][:][/]" |  cut -d' ' -f1 | cut -c 21-)
-minute=$(echo ${minute::2})
-second=$(echo $line | tr -d "[A-Z][a-z][.][:][/]" |  cut -d' ' -f1 | cut -c 24-)
+#size=$(echo $line | tr -d "[A-Z][a-z][.][:][/][\-]" | cut -c 4- | sed 's/[^ ]* //' | tr -d "[ ]")
+#size="$(( $size / 1024 ))"
+#size="$(( $size / 1024 ))"
+#year=$(echo $line | tr -d "[A-Z][a-z][.][:][/]" | cut -c 7- | cut -d' ' -f1 | grep -oP "[0-9]{4}")
+#month=$(echo $line | tr -d "[A-Z][a-z][.][:][/][_]" | cut -d' ' -f1 | cut -c 12-)
+#month=$(echo ${month::2})
+#day=$(echo $line | tr -d "[A-Z][a-z][.][:][/][_]" |  cut -d' ' -f1 | cut -c 14-)
+#day=$(echo ${day::2})
+#hour=$(echo $line | tr -d "[A-Z][a-z][.][:][/][_]" |  cut -d' ' -f1 | cut -c 17-)
+#hour=$(echo ${hour::2})
+#minute=$(echo $line | tr -d "[A-Z][a-z][.][:][/][_]" |  cut -d' ' -f1 | cut -c 19-)
+#minute=$(echo ${minute::2})
+#second=$(echo $line | tr -d "[A-Z][a-z][.][:][/][_]" |  cut -d' ' -f1 | cut -c 21-)
+
+# local:backup/vzdump-openvz-104-2016_02_21-03_49_19.tar.lzo tar.lzo 33512905791
+# nfs-backup:backup/vzdump-openvz-103-2016_02_20-03_34_45.tar.lzo tar.lzo 1962755572
+[[ $line =~ \-$ID\-([0-9]{4})_([0-9]{2})_([0-9]{2})\-([0-9]{2})_([0-9]{2})_([0-9]{2}).*[[:space:]]([0-9]+)$ ]]
+year=${BASH_REMATCH[1]}
+month=${BASH_REMATCH[2]}
+day=${BASH_REMATCH[3]}
+hour=${BASH_REMATCH[4]}
+minute=${BASH_REMATCH[5]}
+second=${BASH_REMATCH[6]}
+let "size=${BASH_REMATCH[7]} / 1024 / 1024"
+#size=$(numfmt --grouping $size)
 
 ##############################################################################################################
 
@@ -92,10 +104,10 @@ if [ -f $LIST ]; then
         rm $LIST
 fi
 
-if [ $TODAY -ge $DATE_LOG_SEC ]; then
-        echo "Critical - $COUNT total backups of vm $ID. Last backup is from $date ${hour}:${minute}:${second}. Size: $size MB"
+if [[ $TODAY -ge $DATE_LOG_SEC ]]; then
+        echo "Critical - $COUNT total backups of vm $ID. Last backup is from $date ${hour}:${minute}:${second}. Size: ${size}MB"
         exit 2
 else
-        echo "OK - $COUNT total backups of vm $ID. Last backup is from $date ${hour}:${minute}:${second}. Size: $size MB"
+        echo "OK - $COUNT total backups of vm $ID. Last backup is from $date ${hour}:${minute}:${second}. Size: ${size}MB"
         exit 0
 fi


### PR DESCRIPTION
I've made a few changes on check_proxmox_backup.sh, tested against Proxmox 3.4. 

I've also improved the parsing of timestamp in the file names using a regex.
